### PR TITLE
feat: adds most of the pricing

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -36,6 +36,7 @@ import { Networks, useNetworkConfiguration } from '../../hooks/useNetworkConfigu
 import { shortKey } from '@/lib/utils';
 import icon from '@/public/meta.jpg';
 import _favicon from '@/public/favicon.ico';
+import { Explorers, useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
 
 interface MenuItem {
   name: string;
@@ -57,10 +58,18 @@ const networks = [
   { label: 'Localnet', value: Networks.Localnet.toString() },
 ];
 
+const explorers = [
+  { label: 'Solana.fm', value: Explorers.SolanaFM.toString() },
+  { label: 'Solscan', value: Explorers.Solscan.toString() },
+  { label: 'X-Ray', value: Explorers.Xray.toString() },
+  { label: 'Solana Explorer', value: Explorers.Solana.toString() },
+];
+
 export function Layout({ children }: { children: React.ReactNode }) {
   const wallet = useWallet();
   const modal = useWalletModal();
   const { network, setNetwork } = useNetworkConfiguration();
+  const { explorer, setExplorer } = useExplorerConfiguration();
   const [opened, { toggle }] = useDisclosure();
   const theme = useMantineTheme();
   const { setColorScheme } = useMantineColorScheme();
@@ -129,10 +138,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
             <Button onClick={() => modal.setVisible(true)}>Connect wallet</Button>
           )}
           <NativeSelect
-            label="Network picker"
+            label="Network"
             data={networks}
             value={network}
             onChange={(e) => setNetwork(e.target.value as Networks)}
+          />
+          <NativeSelect
+            label="Explorer"
+            data={explorers}
+            value={explorer}
+            onChange={(e) => setExplorer(e.target.value as Explorers)}
           />
           <Group justify="center">
             <Link href="https://github.com/Dodecahedr0x/meta-dao-frontend">

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -468,7 +468,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                      <Table.Tr key={order.publicKey.toString()}>
                       <Table.Td>
                         <a href={`https://solana.fm/accounts/${order.publicKey.toString()}`} target="_blank" rel="noreferrer">
-                          {order.account.openOrders[0].clientId.toString()}
+                          {order.account.accountNum}
                         </a>
                       </Table.Td>
                       <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
@@ -516,7 +516,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                       <Table.Tr key={order.publicKey.toString()}>
                        <Table.Td>
                          <a href={`https://solana.fm/accounts/${order.publicKey.toString()}`} target="_blank" rel="noreferrer">
-                           {order.account.openOrders[0].clientId.toString()}
+                           {order.account.accountNum}
                          </a>
                        </Table.Td>
                        <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -475,7 +475,9 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                             : order.account.position.asksBaseLots.toString(),
                         ).format(NUMERAL_FORMAT)}
                       </Table.Td>
-                      <Table.Td>???</Table.Td>
+                      <Table.Td>
+                        {(parseFloat(order.account.openOrders[0].lockedPrice.toString()) / 10000)}
+                      </Table.Td>
                       <Table.Td>{order.account.accountNum}</Table.Td>
                       <Table.Td>
                         <ActionIcon

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -357,17 +357,18 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
         </Group>
         {orderbook ? (
           <Group justify="space-around" align="start">
-            <Stack>
+            <Stack p={0} m={0} gap={0}>
               <Text fw="bolder" size="lg">
                 Pass market orderbook
               </Text>
-              <Group gap="0">
+              <Group w="100%" m={0} p={0} gap="0">
                 {orderbook.pass.asks.parsed.map((ask) => (
-                  <Grid w="100%" gutter={0} mih="md">
+                  <Grid w="100%" gutter={0} mih="md" m={0} p={0}>
+                    <Grid.Col span={3} h="sm" p="0" />
                     <Grid.Col span={1} h="sm" p="0">
                       <Text size="0.6rem">{numeral(ask.price).format(NUMERAL_FORMAT)}</Text>
                     </Grid.Col>
-                    <Grid.Col span="auto">
+                    <Grid.Col span={3}>
                       <Progress
                         key={ask.price + ask.size}
                         value={Math.ceil((ask.price / orderbook.pass.asks.total.price) * 100)}
@@ -378,11 +379,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                   </Grid>
                 ))}
                 {orderbook.pass.bids.parsed.map((bid) => (
-                  <Grid w="100%" gutter={0} mih="md">
-                    <Grid.Col span={1} h="sm" p="0">
-                      <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
-                    </Grid.Col>
-                    <Grid.Col span="auto">
+                  <Grid w="100%" gutter={0} mih="md" m={0} p={0}>
+                    <Grid.Col span={3}>
                       <Progress
                         key={bid.price + bid.size}
                         value={Math.ceil((bid.price / orderbook.pass.bids.total.price) * 100)}
@@ -390,21 +388,26 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                         w="100%"
                       />
                     </Grid.Col>
+                    <Grid.Col span={1} h="sm" p="0">
+                      <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
+                    </Grid.Col>
+                    <Grid.Col span={3} h="sm" p="0" />
                   </Grid>
                 ))}
               </Group>
             </Stack>
-            <Stack>
+            <Stack p={0} m={0} gap={0}>
               <Text fw="bolder" size="lg">
                 Fail market orderbook
               </Text>
-              <Group gap="0">
+              <Group w="100%" gap="0">
                 {orderbook.fail.asks.parsed.map((ask) => (
-                  <Grid w="100%" gutter={0} mih="md">
+                  <Grid w="100%" gutter={0} mih="md" m={0} p={0}>
+                    <Grid.Col span={3} h="sm" p="0" />
                     <Grid.Col span={1} h="sm" p="0">
                       <Text size="0.6rem">{numeral(ask.price).format(NUMERAL_FORMAT)}</Text>
                     </Grid.Col>
-                    <Grid.Col span="auto">
+                    <Grid.Col span={3}>
                       <Progress
                         key={ask.price + ask.size}
                         value={Math.ceil((ask.price / orderbook.fail.asks.total.price) * 100)}
@@ -415,11 +418,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                   </Grid>
                 ))}
                 {orderbook.fail.bids.parsed.map((bid) => (
-                  <Grid w="100%" gutter={0} mih="md">
-                    <Grid.Col span={1} h="sm" p="0">
-                      <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
-                    </Grid.Col>
-                    <Grid.Col span="auto">
+                  <Grid w="100%" gutter={0} mih="md" m={0} p={0}>
+                    <Grid.Col span={3}>
                       <Progress
                         key={bid.price + bid.size}
                         value={Math.ceil((bid.price / orderbook.fail.bids.total.price) * 100)}
@@ -427,6 +427,10 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                         w="100%"
                       />
                     </Grid.Col>
+                    <Grid.Col span={1} h="sm" p="0">
+                      <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
+                    </Grid.Col>
+                    <Grid.Col span={3} h="sm" p="0" />
                   </Grid>
                 ))}
               </Group>

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -446,11 +446,12 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
             <Table>
               <Table.Thead>
                 <Table.Tr>
+                  <Table.Th>Order ID</Table.Th>
                   <Table.Th>Market</Table.Th>
                   <Table.Th>Side</Table.Th>
                   <Table.Th>Quantity</Table.Th>
                   <Table.Th>Price</Table.Th>
-                  <Table.Th>Order ID</Table.Th>
+                  <Table.Th>Amount</Table.Th>
                   <Table.Th>Actions</Table.Th>
                 </Table.Tr>
               </Table.Thead>
@@ -461,7 +462,15 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                     order.account.position.asksBaseLots,
                   );
                   return (
-                    <Table.Tr key={order.publicKey.toString()}>
+                    (
+                      (order.account.openOrders[0].isFree === 0)
+                    ) ? (
+                     <Table.Tr key={order.publicKey.toString()}>
+                      <Table.Td>
+                        <a href={`https://solana.fm/accounts/${order.publicKey.toString()}`} target="_blank" rel="noreferrer">
+                          {order.account.openOrders[0].clientId.toString()}
+                        </a>
+                      </Table.Td>
                       <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
                         {pass ? 'PASS' : 'FAIL'}
                       </Table.Td>
@@ -476,9 +485,23 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                         ).format(NUMERAL_FORMAT)}
                       </Table.Td>
                       <Table.Td>
-                        {(parseFloat(order.account.openOrders[0].lockedPrice.toString()) / 10000)}
+                        ${
+                          (parseFloat(order.account.openOrders[0].lockedPrice.toNumber()) / 10000)
+                        }
                       </Table.Td>
-                      <Table.Td>{order.account.accountNum}</Table.Td>
+                      <Table.Td>
+                        ${ bids ?
+                          (
+                            (order.account.position.bidsBaseLots.toNumber()
+                            * order.account.openOrders[0].lockedPrice.toNumber()) / 10000
+                          )
+                          :
+                          (
+                            (order.account.position.asksBaseLots.toNumber()
+                            * order.account.openOrders[0].lockedPrice.toNumber()) / 10000
+                          )
+                        }
+                      </Table.Td>
                       <Table.Td>
                         <ActionIcon
                           variant="subtle"
@@ -488,7 +511,39 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                           <IconTrash />
                         </ActionIcon>
                       </Table.Td>
-                    </Table.Tr>
+                     </Table.Tr>)
+                    : (
+                      <Table.Tr key={order.publicKey.toString()}>
+                       <Table.Td>
+                         <a href={`https://solana.fm/accounts/${order.publicKey.toString()}`} target="_blank" rel="noreferrer">
+                           {order.account.openOrders[0].clientId.toString()}
+                         </a>
+                       </Table.Td>
+                       <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
+                         {pass ? 'PASS' : 'FAIL'}
+                       </Table.Td>
+                       <Table.Td c={bids ? theme.colors.green[9] : theme.colors.red[9]}>
+                         {bids ? 'BID' : 'ASK'}
+                       </Table.Td>
+                       <Table.Td>
+                        UNKNOWN
+                       </Table.Td>
+                       <Table.Td>
+                        UNKNOWN
+                       </Table.Td>
+                       <Table.Td>
+                        UNKNOWN
+                       </Table.Td>
+                       <Table.Td>
+                         <ActionIcon
+                           variant="subtle"
+                           loading={isCanceling}
+                           onClick={() => handleCancel(order)}
+                         >
+                           <IconTrash />
+                         </ActionIcon>
+                       </Table.Td>
+                      </Table.Tr>)
                   );
                 })}
               </Table.Tbody>

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -27,10 +27,12 @@ import { TWAPOracle, OpenOrdersAccountWithKey, LeafNode } from '@/lib/types';
 import { NUMERAL_FORMAT } from '@/lib/constants';
 import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
 import { useTransactionSender } from '@/hooks/useTransactionSender';
+import { useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
 
 export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number }) {
   const theme = useMantineTheme();
   const { cancelOrderTransactions, settleFundsTransactions } = useOpenbookTwap();
+  const { generateExplorerLink } = useExplorerConfiguration();
   const sender = useTransactionSender();
   const wallet = useWallet();
   const { proposal, markets, orders, mintTokens, placeOrder, loading, fetchOrders } = useProposal({
@@ -516,7 +518,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                     ) ? (
                      <Table.Tr key={order.publicKey.toString()}>
                       <Table.Td>
-                        <a href={`https://solana.fm/accounts/${order.publicKey.toString()}`} target="_blank" rel="noreferrer">
+                        <a href={generateExplorerLink(order.publicKey.toString(), 'account')} target="_blank" rel="noreferrer">
                           {order.account.accountNum}
                         </a>
                       </Table.Td>
@@ -564,7 +566,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                     : (
                       <Table.Tr key={order.publicKey.toString()}>
                        <Table.Td>
-                         <a href={`https://solana.fm/accounts/${order.publicKey.toString()}`} target="_blank" rel="noreferrer">
+                         <a href={generateExplorerLink(order.publicKey.toString(), 'account')} target="_blank" rel="noreferrer">
                            {order.account.accountNum}
                          </a>
                        </Table.Td>

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -463,7 +463,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
           <Stack>
             <Group justify="space-between">
               <Text fw="bolder" size="xl">
-                Open orders
+                Orders
               </Text>
               <ActionIcon variant="subtle" onClick={() => fetchOrders()}>
                 <IconRefresh />

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -391,7 +391,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
               <Group gap="0">
                 {orderbook.pass.asks?.parsed.map((ask) => (
                   <Grid w="100%" gutter={0} mih="md">
-                    <Grid.Col span={1} h="sm" p="0">
+                    <Grid.Col span={3} />
+                    <Grid.Col span={1.5} h="sm" p="0">
                       <Text size="0.6rem">{numeral(ask.price).format(NUMERAL_FORMAT)}</Text>
                     </Grid.Col>
                     <Grid.Col span={3}>
@@ -410,10 +411,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                 ))}
                 {orderbook.pass.bids?.parsed.map((bid) => (
                   <Grid w="100%" gutter={0} mih="md">
-                    <Grid.Col span={1} h="sm" p="0">
-                      <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
-                    </Grid.Col>
-                    <Grid.Col span="auto">
+                    <Grid.Col span={3}>
                       <Progress
                         key={bid.price + bid.size}
                         value={
@@ -425,7 +423,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                         w="100%"
                       />
                     </Grid.Col>
-                    <Grid.Col span={1} h="sm" p="0">
+                    <Grid.Col span={1.5} h="sm" p="0" ml={2}>
                       <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
                     </Grid.Col>
                     <Grid.Col span={3} h="sm" p="0" />
@@ -440,7 +438,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
               <Group gap="0">
                 {orderbook.fail.asks?.parsed.map((ask) => (
                   <Grid w="100%" gutter={0} mih="md">
-                    <Grid.Col span={1} h="sm" p="0">
+                    <Grid.Col span={3} h="sm" p="0" />
+                    <Grid.Col span={1.5} h="sm" p="0">
                       <Text size="0.6rem">{numeral(ask.price).format(NUMERAL_FORMAT)}</Text>
                     </Grid.Col>
                     <Grid.Col span={3}>
@@ -459,10 +458,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                 ))}
                 {orderbook.fail.bids?.parsed.map((bid) => (
                   <Grid w="100%" gutter={0} mih="md">
-                    <Grid.Col span={1} h="sm" p="0">
-                      <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
-                    </Grid.Col>
-                    <Grid.Col span="auto">
+                    <Grid.Col span={3}>
                       <Progress
                         key={bid.price + bid.size}
                         value={
@@ -474,7 +470,7 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                         w="100%"
                       />
                     </Grid.Col>
-                    <Grid.Col span={1} h="sm" p="0">
+                    <Grid.Col span={1.5} h="sm" p="0">
                       <Text size="0.6rem">{numeral(bid.price).format(NUMERAL_FORMAT)}</Text>
                     </Grid.Col>
                     <Grid.Col span={3} h="sm" p="0" />

--- a/hooks/useExplorerConfiguration.ts
+++ b/hooks/useExplorerConfiguration.ts
@@ -1,5 +1,5 @@
 import { useLocalStorage } from '@mantine/hooks';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export enum Explorers {
   SolanaFM = 'solanafm',
@@ -12,8 +12,10 @@ export function useExplorerConfiguration() {
   const [explorer, setExplorer] = useLocalStorage<Explorers>({
     key: 'meta-dao-explorer-configuration',
     defaultValue: Explorers.SolanaFM,
+    getInitialValueInEffect: true,
   });
-  const endpoint = useMemo(() => {
+
+  const url = useMemo(() => {
     switch (explorer) {
       case Explorers.SolanaFM:
         return 'https://solana.fm/';
@@ -28,5 +30,28 @@ export function useExplorerConfiguration() {
     }
   }, [explorer]);
 
-  return { endpoint, explorer, setExplorer };
+  const matchSuffix = useCallback(
+    (type: string) => {
+      switch (type) {
+        case 'account':
+          // @ts-ignore
+          if ([Explorers.Solscan, Explorers.Solana].includes(explorer)) {
+            return `${url}address/`;
+          }
+          return `${url}account/`;
+        case 'transaction':
+          return `${url}tx/`;
+        default:
+          return url;
+      }
+    },
+    [explorer, url]
+  );
+
+  const generateExplorerLink = useCallback(
+    (element: string, type: string) => matchSuffix(type) + element,
+    [explorer]
+  );
+
+  return { url, explorer, setExplorer, generateExplorerLink };
 }

--- a/hooks/useExplorerConfiguration.ts
+++ b/hooks/useExplorerConfiguration.ts
@@ -1,0 +1,32 @@
+import { useLocalStorage } from '@mantine/hooks';
+import { useMemo } from 'react';
+
+export enum Explorers {
+  SolanaFM = 'solanafm',
+  Solscan = 'solscan',
+  Xray = 'xray',
+  Solana = 'solana'
+}
+
+export function useExplorerConfiguration() {
+  const [explorer, setExplorer] = useLocalStorage<Explorers>({
+    key: 'meta-dao-explorer-configuration',
+    defaultValue: Explorers.SolanaFM,
+  });
+  const endpoint = useMemo(() => {
+    switch (explorer) {
+      case Explorers.SolanaFM:
+        return 'https://solana.fm/';
+      case Explorers.Solscan:
+        return 'https://solscan.io/';
+      case Explorers.Xray:
+        return 'https://xray.helius.xyz/';
+      case Explorers.Solana:
+        return 'https://explorer.solana.com/';
+      default:
+        return 'https://explorer.solana.com/';
+    }
+  }, [explorer]);
+
+  return { endpoint, explorer, setExplorer };
+}

--- a/hooks/useTokenAmount.ts
+++ b/hooks/useTokenAmount.ts
@@ -13,14 +13,24 @@ export function useTokenAmount(mint?: PublicKey, owner?: PublicKey) {
   const [amount, setAmount] = useState<TokenAmount>();
 
   const fetchAmount = async () => {
-    if (account && connection) {
-      setAmount((await connection.getTokenAccountBalance(account)).value);
+    if (account && connection && wallet) {
+      const defaultAmount: TokenAmount = {
+        amount: '0.0',
+        decimals: 0.0,
+        uiAmount: 0.0,
+      };
+      try {
+        setAmount((await connection.getTokenAccountBalance(account)).value);
+      } catch (err) {
+        console.error(`Error with this account fetch ${account.toString()}, please review issue and solve.`);
+        setAmount(defaultAmount);
+      }
     }
   };
 
   useEffect(() => {
     fetchAmount();
-  }, [account, connection]);
+  }, [account, connection, wallet]);
 
   return { amount, account, fetchAmount };
 }

--- a/hooks/useTokenAmount.ts
+++ b/hooks/useTokenAmount.ts
@@ -20,15 +20,11 @@ export function useTokenAmount(mint?: PublicKey, owner?: PublicKey) {
         uiAmount: 0.0,
       };
       try {
-        if (typeof (account) !== 'string') {
-          setAmount(defaultAmount);
+        const accountTokenBalance = (await connection.getTokenAccountBalance(account)).value;
+        if (accountTokenBalance.uiAmount != null) {
+          setAmount(accountTokenBalance);
         } else {
-          const accountTokenBalance = (await connection.getTokenAccountBalance(account)).value;
-          if (accountTokenBalance.uiAmount != null) {
-            setAmount(accountTokenBalance);
-          } else {
-            setAmount(defaultAmount);
-          }
+          setAmount(defaultAmount);
         }
       } catch (err) {
         console.error(err);
@@ -38,12 +34,8 @@ export function useTokenAmount(mint?: PublicKey, owner?: PublicKey) {
   };
 
   useEffect(() => {
-    if (wallet) {
-      fetchAmount();
-    } else {
-      console.error('waiting for wallet connection');
-    }
-  }, [account, wallet]);
+    fetchAmount();
+  }, [account]);
 
   return { amount, account, fetchAmount };
 }

--- a/hooks/useTokenAmount.ts
+++ b/hooks/useTokenAmount.ts
@@ -19,10 +19,19 @@ export function useTokenAmount(mint?: PublicKey, owner?: PublicKey) {
         decimals: 0.0,
         uiAmount: 0.0,
       };
-      const accountTokenBalance = (await connection.getTokenAccountBalance(account)).value;
-      if (accountTokenBalance.uiAmount != null) {
-        setAmount(accountTokenBalance);
-      } else {
+      try {
+        if (typeof (account) !== 'string') {
+          setAmount(defaultAmount);
+        } else {
+          const accountTokenBalance = (await connection.getTokenAccountBalance(account)).value;
+          if (accountTokenBalance.uiAmount != null) {
+            setAmount(accountTokenBalance);
+          } else {
+            setAmount(defaultAmount);
+          }
+        }
+      } catch (err) {
+        console.error(err);
         setAmount(defaultAmount);
       }
     }

--- a/hooks/useTokenAmount.ts
+++ b/hooks/useTokenAmount.ts
@@ -13,14 +13,28 @@ export function useTokenAmount(mint?: PublicKey, owner?: PublicKey) {
   const [amount, setAmount] = useState<TokenAmount>();
 
   const fetchAmount = async () => {
-    if (account) {
-      setAmount((await connection.getTokenAccountBalance(account)).value);
+    if (wallet && account) {
+      const defaultAmount: TokenAmount = {
+        amount: '0.0',
+        decimals: 0.0,
+        uiAmount: 0.0,
+      };
+      const accountTokenBalance = (await connection.getTokenAccountBalance(account)).value;
+      if (accountTokenBalance.uiAmount != null) {
+        setAmount(accountTokenBalance);
+      } else {
+        setAmount(defaultAmount);
+      }
     }
   };
 
   useEffect(() => {
-    fetchAmount();
-  }, [account]);
+    if (wallet) {
+      fetchAmount();
+    } else {
+      console.error('waiting for wallet connection');
+    }
+  }, [account, wallet]);
 
   return { amount, account, fetchAmount };
 }


### PR DESCRIPTION
need to fix units to match lot size of quote or something

Potential for merge, with some rough edges. But could at least be a great start for someone who knows how to fix it :)

- [ ] padding / margin for the order book display is out of whack
- [ ] settle funds tx gets built and sent to the wallet, but fails simulation
- [x] explorer selector doesn't do anything
- [ ] orders in various statuses are displayed, but unsure if they're cancelled or filled
- [ ] likely some shit I'm not good at janky left over

For the orders, we can get pricing from the open orders, my assumption is you'll have to do something else with the account state given it's a trade or cancelled or filled etc.

For the settle funds I think the error is with `userBaseAccount` and `userQuoteAccount` I'm not sure how to determine that.

For the explorer selection, it's just something where we need to fetch the configured value and append it with proper `tx/` or `account/` to make it behave.