### PR TITLE
feat: adds support for settling funds

### DIFF
--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
-  ActionIcon,
   Button,
   Fieldset,
   Grid,
@@ -10,32 +9,21 @@ import {
   Progress,
   SegmentedControl,
   Stack,
-  Table,
   Text,
   TextInput,
-  useMantineTheme,
 } from '@mantine/core';
 import Link from 'next/link';
-import { useWallet } from '@solana/wallet-adapter-react';
-import { IconExternalLink, IconRefresh, IconTrash, Icon3dRotate } from '@tabler/icons-react';
+import { IconExternalLink } from '@tabler/icons-react';
 import numeral from 'numeral';
-import { BN } from '@coral-xyz/anchor';
 import { useProposal } from '@/hooks/useProposal';
 import { useTokens } from '@/hooks/useTokens';
 import { useTokenAmount } from '@/hooks/useTokenAmount';
-import { TWAPOracle, OpenOrdersAccountWithKey, LeafNode } from '@/lib/types';
+import { TWAPOracle, LeafNode } from '@/lib/types';
 import { NUMERAL_FORMAT } from '@/lib/constants';
-import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
-import { useTransactionSender } from '@/hooks/useTransactionSender';
-import { useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
+import { ProposalOrdersCard } from './ProposalOrdersCard';
 
 export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number }) {
-  const theme = useMantineTheme();
-  const { cancelOrderTransactions, settleFundsTransactions } = useOpenbookTwap();
-  const { generateExplorerLink } = useExplorerConfiguration();
-  const sender = useTransactionSender();
-  const wallet = useWallet();
-  const { proposal, markets, orders, mintTokens, placeOrder, loading, fetchOrders } = useProposal({
+  const { proposal, markets, orders, mintTokens, placeOrder, loading } = useProposal({
     fromNumber: proposalNumber,
   });
   const [mintBaseAmount, setMintBaseAmount] = useState<number>();
@@ -60,8 +48,6 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
   const [passPrice, setPassPrice] = useState<number>(0);
   const [failPrice, setFailPrice] = useState<number>(0);
   const [orderType, setOrderType] = useState<string>('Limit');
-  const [isCanceling, setIsCanceling] = useState<boolean>(false);
-  const [isSettling, setIsSettling] = useState<boolean>(false);
 
   const orderbook = useMemo(() => {
     if (!markets) return;
@@ -86,51 +72,6 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
       fail: { asks: getSide(markets.failAsks), bids: getSide(markets.failBids, true) },
     };
   }, [markets]);
-
-  const handleCancel = useCallback(
-    async (order: OpenOrdersAccountWithKey) => {
-      if (!proposal || !markets) return;
-
-      const txs = await cancelOrderTransactions(
-        new BN(order.account.accountNum),
-        proposal.account.openbookPassMarket.equals(order.account.market)
-          ? { publicKey: proposal.account.openbookPassMarket, account: markets.pass }
-          : { publicKey: proposal.account.openbookFailMarket, account: markets.fail },
-      );
-
-      if (!wallet.publicKey || !txs) return;
-
-      try {
-        setIsCanceling(true);
-        await sender.send(txs);
-        setTimeout(() => fetchOrders(), 3000);
-      } finally {
-        setIsCanceling(false);
-      }
-    },
-    [proposal, cancelOrderTransactions, fetchOrders, sender],
-  );
-
-  const handleSettleFunds = useCallback(
-    async (order: OpenOrdersAccountWithKey) => {
-      if (!proposal || !markets) return;
-      const txs = await settleFundsTransactions(
-        new BN(order.account.accountNum),
-        proposal.account.openbookPassMarket.equals(order.account.market)
-          ? { publicKey: proposal.account.openbookPassMarket, account: markets.pass }
-          : { publicKey: proposal.account.openbookFailMarket, account: markets.fail },
-      );
-      if (!wallet.publicKey || !txs) return;
-      try {
-        setIsSettling(true);
-        await sender.send(txs);
-        setTimeout(() => fetchOrders(), 3000);
-      } finally {
-        setIsSettling(false);
-      }
-    },
-    [proposal, settleFundsTransactions, fetchOrders, sender],
-  );
 
   const handleMint = useCallback(
     async (fromBase?: boolean) => {
@@ -389,8 +330,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                 Pass market orderbook
               </Text>
               <Group gap="0">
-                {orderbook.pass.asks?.parsed.map((ask) => (
-                  <Grid w="100%" gutter={0} mih="md">
+                {orderbook.pass.asks?.parsed.map((ask, index) => (
+                  <Grid key={index} w="100%" gutter={0} mih="md">
                     <Grid.Col span={3} />
                     <Grid.Col span={1.5} h="sm" p="0">
                       <Text size="0.6rem">{numeral(ask.price).format(NUMERAL_FORMAT)}</Text>
@@ -409,8 +350,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                     </Grid.Col>
                   </Grid>
                 ))}
-                {orderbook.pass.bids?.parsed.map((bid) => (
-                  <Grid w="100%" gutter={0} mih="md">
+                {orderbook.pass.bids?.parsed.map((bid, index) => (
+                  <Grid key={index} w="100%" gutter={0} mih="md">
                     <Grid.Col span={3}>
                       <Progress
                         key={bid.price + bid.size}
@@ -436,8 +377,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                 Fail market orderbook
               </Text>
               <Group gap="0">
-                {orderbook.fail.asks?.parsed.map((ask) => (
-                  <Grid w="100%" gutter={0} mih="md">
+                {orderbook.fail.asks?.parsed.map((ask, index) => (
+                  <Grid key={index} w="100%" gutter={0} mih="md">
                     <Grid.Col span={3} h="sm" p="0" />
                     <Grid.Col span={1.5} h="sm" p="0">
                       <Text size="0.6rem">{numeral(ask.price).format(NUMERAL_FORMAT)}</Text>
@@ -456,8 +397,8 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
                     </Grid.Col>
                   </Grid>
                 ))}
-                {orderbook.fail.bids?.parsed.map((bid) => (
-                  <Grid w="100%" gutter={0} mih="md">
+                {orderbook.fail.bids?.parsed.map((bid, index) => (
+                  <Grid key={index} w="100%" gutter={0} mih="md">
                     <Grid.Col span={3}>
                       <Progress
                         key={bid.price + bid.size}
@@ -481,121 +422,11 @@ export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number 
           </Group>
         ) : null}
         {proposal && orders ? (
-          <Stack>
-            <Group justify="space-between">
-              <Text fw="bolder" size="xl">
-                Orders
-              </Text>
-              <ActionIcon variant="subtle" onClick={() => fetchOrders()}>
-                <IconRefresh />
-              </ActionIcon>
-            </Group>
-            <Table>
-              <Table.Thead>
-                <Table.Tr>
-                  <Table.Th>Order ID</Table.Th>
-                  <Table.Th>Market</Table.Th>
-                  <Table.Th>Side</Table.Th>
-                  <Table.Th>Quantity</Table.Th>
-                  <Table.Th>Price</Table.Th>
-                  <Table.Th>Amount</Table.Th>
-                  <Table.Th>Actions</Table.Th>
-                </Table.Tr>
-              </Table.Thead>
-              <Table.Tbody>
-                {orders.map((order) => {
-                  const pass = order.account.market.equals(proposal.account.openbookPassMarket);
-                  const bids = order.account.position.bidsBaseLots.gt(
-                    order.account.position.asksBaseLots,
-                  );
-                  return (
-                    (
-                      (order.account.openOrders[0].isFree === 0)
-                    ) ? (
-                     <Table.Tr key={order.publicKey.toString()}>
-                      <Table.Td>
-                        <a href={generateExplorerLink(order.publicKey.toString(), 'account')} target="_blank" rel="noreferrer">
-                          {order.account.accountNum}
-                        </a>
-                      </Table.Td>
-                      <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
-                        {pass ? 'PASS' : 'FAIL'}
-                      </Table.Td>
-                      <Table.Td c={bids ? theme.colors.green[9] : theme.colors.red[9]}>
-                        {bids ? 'BID' : 'ASK'}
-                      </Table.Td>
-                      <Table.Td>
-                        {numeral(
-                          bids
-                            ? order.account.position.bidsBaseLots.toString()
-                            : order.account.position.asksBaseLots.toString(),
-                        ).format(NUMERAL_FORMAT)}
-                      </Table.Td>
-                      <Table.Td>
-                        ${
-                          (parseFloat(order.account.openOrders[0].lockedPrice.toNumber()) / 10000)
-                        }
-                      </Table.Td>
-                      <Table.Td>
-                        ${ bids ?
-                          (
-                            (order.account.position.bidsBaseLots.toNumber()
-                            * order.account.openOrders[0].lockedPrice.toNumber()) / 10000
-                          )
-                          :
-                          (
-                            (order.account.position.asksBaseLots.toNumber()
-                            * order.account.openOrders[0].lockedPrice.toNumber()) / 10000
-                          )
-                        }
-                      </Table.Td>
-                      <Table.Td>
-                        <ActionIcon
-                          variant="subtle"
-                          loading={isCanceling}
-                          onClick={() => handleCancel(order)}
-                        >
-                          <IconTrash />
-                        </ActionIcon>
-                      </Table.Td>
-                     </Table.Tr>)
-                    : (
-                      <Table.Tr key={order.publicKey.toString()}>
-                       <Table.Td>
-                         <a href={generateExplorerLink(order.publicKey.toString(), 'account')} target="_blank" rel="noreferrer">
-                           {order.account.accountNum}
-                         </a>
-                       </Table.Td>
-                       <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
-                         {pass ? 'PASS' : 'FAIL'}
-                       </Table.Td>
-                       <Table.Td c={bids ? theme.colors.green[9] : theme.colors.red[9]}>
-                         {bids ? 'BID' : 'ASK'}
-                       </Table.Td>
-                       <Table.Td>
-                        UNKNOWN
-                       </Table.Td>
-                       <Table.Td>
-                        UNKNOWN
-                       </Table.Td>
-                       <Table.Td>
-                        UNKNOWN
-                       </Table.Td>
-                       <Table.Td>
-                         <ActionIcon
-                           variant="subtle"
-                           loading={isSettling}
-                           onClick={() => handleSettleFunds(order)}
-                         >
-                           <Icon3dRotate />
-                         </ActionIcon>
-                       </Table.Td>
-                      </Table.Tr>)
-                  );
-                })}
-              </Table.Tbody>
-            </Table>
-          </Stack>
+          <ProposalOrdersCard
+            markets={markets}
+            proposal={proposal}
+            orders={orders}
+          />
         ) : null}
       </Stack>
     </Stack>

--- a/components/Proposals/ProposalOrdersCard.tsx
+++ b/components/Proposals/ProposalOrdersCard.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useState } from 'react';
+import {
+  ActionIcon,
+  Group,
+  Stack,
+  Table,
+  Text,
+  useMantineTheme,
+} from '@mantine/core';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { BN } from '@coral-xyz/anchor';
+import { IconRefresh, IconTrash, Icon3dRotate } from '@tabler/icons-react';
+import numeral from 'numeral';
+import { useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
+import { OpenOrdersAccountWithKey, ProposalAccountWithKey, Markets } from '@/lib/types';
+import { useProposal } from '@/hooks/useProposal';
+import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
+import { useTransactionSender } from '@/hooks/useTransactionSender';
+import { NUMERAL_FORMAT } from '@/lib/constants';
+
+export function ProposalOrdersCard(
+  { markets, orders, proposal }: {
+    markets: Markets,
+    orders: OpenOrdersAccountWithKey[],
+    proposal: ProposalAccountWithKey
+  }
+) {
+  const theme = useMantineTheme();
+
+  const sender = useTransactionSender();
+  const wallet = useWallet();
+  const { fetchOrders } = useProposal({
+    fromNumber: proposal.account.number,
+  });
+  const { cancelOrderTransactions, settleFundsTransactions } = useOpenbookTwap();
+  const { generateExplorerLink } = useExplorerConfiguration();
+
+  const [isCanceling, setIsCanceling] = useState<boolean>(false);
+  const [isSettling, setIsSettling] = useState<boolean>(false);
+
+  const handleCancel = useCallback(
+    async (order: OpenOrdersAccountWithKey) => {
+      if (!proposal || !markets) return;
+
+      const txs = await cancelOrderTransactions(
+        new BN(order.account.accountNum),
+        proposal.account.openbookPassMarket.equals(order.account.market)
+          ? { publicKey: proposal.account.openbookPassMarket, account: markets.pass }
+          : { publicKey: proposal.account.openbookFailMarket, account: markets.fail },
+      );
+
+      if (!wallet.publicKey || !txs) return;
+
+      try {
+        setIsCanceling(true);
+        await sender.send(txs);
+        setTimeout(() => fetchOrders(), 3000);
+      } finally {
+        setIsCanceling(false);
+      }
+    },
+    [proposal, cancelOrderTransactions, fetchOrders, sender],
+  );
+
+  const handleSettleFunds = useCallback(
+    async (order: OpenOrdersAccountWithKey, passMarket: boolean) => {
+      if (!proposal || !markets) return;
+      const txs = await settleFundsTransactions(
+        new BN(order.account.accountNum),
+        passMarket,
+        proposal,
+        proposal.account.openbookPassMarket.equals(order.account.market)
+          ? { publicKey: proposal.account.openbookPassMarket, account: markets.pass }
+          : { publicKey: proposal.account.openbookFailMarket, account: markets.fail },
+      );
+      if (!wallet.publicKey || !txs) return;
+      try {
+        setIsSettling(true);
+        await sender.send(txs);
+        setTimeout(() => fetchOrders(), 3000);
+      } finally {
+        setIsSettling(false);
+      }
+    },
+    [proposal, settleFundsTransactions, fetchOrders, sender],
+  );
+
+  return (
+    <Stack>
+      <Group justify="space-between">
+        <Text fw="bolder" size="xl">
+          Orders
+        </Text>
+        <ActionIcon variant="subtle" onClick={() => fetchOrders()}>
+          <IconRefresh />
+        </ActionIcon>
+      </Group>
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Order ID</Table.Th>
+            <Table.Th>Market</Table.Th>
+            <Table.Th>Side</Table.Th>
+            <Table.Th>Quantity</Table.Th>
+            <Table.Th>Price</Table.Th>
+            <Table.Th>Amount</Table.Th>
+            <Table.Th>Actions</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {orders.map((order) => {
+            const pass = order.account.market.equals(proposal.account.openbookPassMarket);
+            const bids = order.account.position.bidsBaseLots.gt(
+              order.account.position.asksBaseLots,
+            );
+            return (
+              (
+                (order.account.openOrders[0].isFree === 0)
+              ) ? (
+                <Table.Tr key={order.publicKey.toString()}>
+                <Table.Td>
+                  <a href={generateExplorerLink(order.publicKey.toString(), 'account')} target="_blank" rel="noreferrer">
+                    {order.account.accountNum}
+                  </a>
+                </Table.Td>
+                <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
+                  {pass ? 'PASS' : 'FAIL'}
+                </Table.Td>
+                <Table.Td c={bids ? theme.colors.green[9] : theme.colors.red[9]}>
+                  {bids ? 'BID' : 'ASK'}
+                </Table.Td>
+                <Table.Td>
+                  {numeral(
+                    bids
+                      ? order.account.position.bidsBaseLots.toString()
+                      : order.account.position.asksBaseLots.toString(),
+                  ).format(NUMERAL_FORMAT)}
+                </Table.Td>
+                <Table.Td>
+                  ${
+                    (parseFloat(order.account.openOrders[0].lockedPrice.toNumber()) / 10000)
+                  }
+                </Table.Td>
+                <Table.Td>
+                  ${ bids ?
+                    (
+                      (order.account.position.bidsBaseLots.toNumber()
+                      * order.account.openOrders[0].lockedPrice.toNumber()) / 10000
+                    )
+                    :
+                    (
+                      (order.account.position.asksBaseLots.toNumber()
+                      * order.account.openOrders[0].lockedPrice.toNumber()) / 10000
+                    )
+                  }
+                </Table.Td>
+                <Table.Td>
+                  <ActionIcon
+                    variant="subtle"
+                    loading={isCanceling}
+                    onClick={() => handleCancel(order)}
+                  >
+                    <IconTrash />
+                  </ActionIcon>
+                </Table.Td>
+                </Table.Tr>)
+              : (
+                <Table.Tr key={order.publicKey.toString()}>
+                  <Table.Td>
+                    <a href={generateExplorerLink(order.publicKey.toString(), 'account')} target="_blank" rel="noreferrer">
+                      {order.account.accountNum}
+                    </a>
+                  </Table.Td>
+                  <Table.Td c={pass ? theme.colors.green[9] : theme.colors.red[9]}>
+                    {pass ? 'PASS' : 'FAIL'}
+                  </Table.Td>
+                  <Table.Td c={bids ? theme.colors.green[9] : theme.colors.red[9]}>
+                    {bids ? 'BID' : 'ASK'}
+                  </Table.Td>
+                  <Table.Td>
+                  UNKNOWN
+                  </Table.Td>
+                  <Table.Td>
+                  UNKNOWN
+                  </Table.Td>
+                  <Table.Td>
+                  UNKNOWN
+                  </Table.Td>
+                  <Table.Td>
+                    <ActionIcon
+                      variant="subtle"
+                      loading={isSettling}
+                      onClick={() => handleSettleFunds(order, pass)}
+                    >
+                      <Icon3dRotate />
+                    </ActionIcon>
+                  </Table.Td>
+                </Table.Tr>)
+            );
+          })}
+        </Table.Tbody>
+      </Table>
+    </Stack>
+  );
+}

--- a/components/Proposals/ProposalOrdersCard.tsx
+++ b/components/Proposals/ProposalOrdersCard.tsx
@@ -29,7 +29,7 @@ export function ProposalOrdersCard(
 
   const sender = useTransactionSender();
   const wallet = useWallet();
-  const { fetchOrders } = useProposal({
+  const { fetchOpenOrders } = useProposal({
     fromNumber: proposal.account.number,
   });
   const { cancelOrderTransactions, settleFundsTransactions } = useOpenbookTwap();
@@ -54,12 +54,14 @@ export function ProposalOrdersCard(
       try {
         setIsCanceling(true);
         await sender.send(txs);
-        setTimeout(() => fetchOrders(), 3000);
+        setTimeout(() => fetchOpenOrders(), 3000);
+      } catch (err) {
+        console.error(err);
       } finally {
         setIsCanceling(false);
       }
     },
-    [proposal, cancelOrderTransactions, fetchOrders, sender],
+    [proposal, cancelOrderTransactions, fetchOpenOrders, sender],
   );
 
   const handleSettleFunds = useCallback(
@@ -77,12 +79,14 @@ export function ProposalOrdersCard(
       try {
         setIsSettling(true);
         await sender.send(txs);
-        setTimeout(() => fetchOrders(), 3000);
+        setTimeout(() => fetchOpenOrders(), 3000);
+      } catch (err) {
+        console.error(err);
       } finally {
         setIsSettling(false);
       }
     },
-    [proposal, settleFundsTransactions, fetchOrders, sender],
+    [proposal, settleFundsTransactions, fetchOpenOrders, sender],
   );
 
   return (
@@ -91,7 +95,7 @@ export function ProposalOrdersCard(
         <Text fw="bolder" size="xl">
           Orders
         </Text>
-        <ActionIcon variant="subtle" onClick={() => fetchOrders()}>
+        <ActionIcon variant="subtle" onClick={() => fetchOpenOrders()}>
           <IconRefresh />
         </ActionIcon>
       </Group>

--- a/hooks/useConditionalVault.ts
+++ b/hooks/useConditionalVault.ts
@@ -18,7 +18,16 @@ export function useConditionalVault() {
     () => new Program<ConditionalVault>(CONDITIONAL_VAULT_IDL, programId, provider),
     [provider, programId],
   );
+
   const { tokens } = useTokens();
+
+  const getVaultMint = useCallback(
+    async (vault: PublicKey) => {
+      const storedVault = await program.account.conditionalVault.fetch(vault);
+      return storedVault;
+    },
+    [program, tokens],
+  );
 
   const initializeVault = useCallback(
     async (settlementAuthority: PublicKey, underlyingTokenMint: PublicKey, nonce: BN) => {
@@ -132,5 +141,5 @@ export function useConditionalVault() {
     [program, tokens],
   );
 
-  return { program, initializeVault, mintConditionalTokens };
+  return { program, initializeVault, mintConditionalTokens, getVaultMint };
 }

--- a/hooks/useProposal.ts
+++ b/hooks/useProposal.ts
@@ -42,7 +42,8 @@ export function useProposal({
       )[0],
     [proposals, fromProposal],
   );
-  const fetchOrders = useCallback(async () => {
+
+  const fetchOpenOrders = useCallback(async () => {
     if (!proposal || !openbook || !wallet.publicKey) {
       return;
     }
@@ -63,9 +64,9 @@ export function useProposal({
 
   useEffect(() => {
     if (!orders) {
-      fetchOrders();
+      fetchOpenOrders();
     }
-  }, [orders, markets, fetchOrders]);
+  }, [orders, markets, fetchOpenOrders]);
 
   const fetchMarkets = useCallback(async () => {
     if (!wallet.publicKey || !proposal || !openbook || !openbookTwap || !openbookTwap.views) return;
@@ -263,12 +264,12 @@ export function useProposal({
         }
 
         await fetchMarkets();
-        await fetchOrders();
+        await fetchOpenOrders();
       } finally {
         setLoading(false);
       }
     },
-    [wallet, connection, placeOrderTransactions],
+    [wallet, proposal, markets, connection, placeOrderTransactions],
   );
 
   return {
@@ -276,7 +277,7 @@ export function useProposal({
     markets,
     orders,
     loading,
-    fetchOrders,
+    fetchOpenOrders,
     fetchMarkets,
     mintTokensTransactions,
     mintTokens,


### PR DESCRIPTION
Adds support for settling the accounts. This doesn't remove them from the orders list and still not 100% sure there aren't more accounts or things to be settled.

This breaks up the component from proposal detail into another component for the table for orders.

Adds function to the conditional vault to get the storedVault for accessing the tokenMint for the user.