### PR TITLE
feat: adds split table structure and some filtering

### DIFF
--- a/hooks/useWeb3.ts
+++ b/hooks/useWeb3.ts
@@ -1,0 +1,20 @@
+import { useConnection, useWallet } from '@solana/wallet-adapter-react';
+import { useCallback } from 'react';
+
+export const useWeb3 = () => {
+  const { connection } = useConnection();
+  const wallet = useWallet();
+
+  const closeOrderAccount = useCallback(
+    async () => {
+      if (!connection || !wallet.publicKey || !wallet.signAllTransactions) {
+        throw new Error('Bad wallet connection');
+      }
+
+      return null;
+    },
+    [wallet.publicKey, connection],
+  );
+
+  return { closeOrderAccount };
+};


### PR DESCRIPTION
This is the WIP, but can be landed for getting close account stuffs. It splits the orders into their respective statuses, which is why I want to land this right now, even though the feature is incomplete.