### PR TITLE
fix: checks for solflare without auto connect

### DIFF
--- a/hooks/useConditionalVault.ts
+++ b/hooks/useConditionalVault.ts
@@ -128,7 +128,7 @@ export function useConditionalVault() {
       vault: VaultAccount,
       fromBaseVault?: boolean,
     ) => {
-      if (!tokens || !provider) {
+      if (!tokens || !provider || !provider.publicKey) {
         return;
       }
       const token = Object.values(tokens).find(

--- a/hooks/useProposal.ts
+++ b/hooks/useProposal.ts
@@ -164,7 +164,7 @@ export function useProposal({
 
   const mintTokensTransactions = useCallback(
     async (amount: number, fromBase?: boolean) => {
-      if (!proposal || !markets) {
+      if (!proposal || !markets || !wallet.publicKey) {
         return;
       }
 
@@ -183,6 +183,9 @@ export function useProposal({
 
   const mintTokens = useCallback(
     async (amount: number, fromBase?: boolean) => {
+      if (!wallet.publicKey) {
+        return;
+      }
       const txs = await mintTokensTransactions(amount, fromBase);
       if (!txs || !proposal || !wallet.publicKey || !wallet.signAllTransactions) {
         return;


### PR DESCRIPTION
So without auto connect selected, for some reason the wallet public key isn't available like it is for phantom. So these checks make sure we have the key (whatever reason, I don't know).

We can probably surface wallet / public key check to top level and stop checking everywhere...