### PR TITLE
Keep previoous market info

### DIFF
--- a/contexts/AutocratContext.tsx
+++ b/contexts/AutocratContext.tsx
@@ -251,6 +251,7 @@ export function AutocratProvider({ children }: { children: ReactNode }) {
       );
 
       setAllMarketsInfo({
+        ...allMarketsInfo,
         [proposal.publicKey.toString()]: {
           pass,
           passAsks,
@@ -265,7 +266,7 @@ export function AutocratProvider({ children }: { children: ReactNode }) {
         },
       });
     }, 1000),
-    [vaultProgram, openbook, openbookTwap],
+    [allMarketsInfo, vaultProgram, openbook, openbookTwap],
   );
   const fetchOpenOrders = useCallback(
     debounce<[ProposalAccountWithKey, PublicKey]>(
@@ -281,7 +282,6 @@ export function AutocratProvider({ children }: { children: ReactNode }) {
           { memcmp: { offset: 8, bytes: owner.toBase58() } },
           { memcmp: { offset: 40, bytes: proposal.account.openbookFailMarket.toBase58() } },
         ]);
-        console.log(passOrders, failOrders);
         setAllOrders({
           [proposal.publicKey.toString()]: passOrders
             .concat(failOrders)
@@ -293,12 +293,22 @@ export function AutocratProvider({ children }: { children: ReactNode }) {
     [openbook],
   );
 
+  useEffect(() => {
+    if (!proposals) {
+      fetchProposals();
+    }
+  }, [proposals]);
+
+  useEffect(() => {
+    if (!daoState) {
+      fetchState();
+    }
+  }, [daoState]);
+
   // Reset on network change
   useEffect(() => {
     setProposals(undefined);
     setDaoState(undefined);
-    fetchProposals();
-    fetchState();
   }, [network]);
 
   return (

--- a/hooks/useProposal.ts
+++ b/hooks/useProposal.ts
@@ -50,7 +50,7 @@ export function useProposal({
           t.account.number === fromNumber ||
           t.publicKey.toString() === fromProposal?.publicKey.toString(),
       )[0],
-    [proposals, fromProposal],
+    [proposals, fromProposal, fromNumber],
   );
   const markets = proposal ? allMarketsInfo[proposal.publicKey.toString()] : undefined;
   const orders = proposal ? allOrders[proposal.publicKey.toString()] : undefined;


### PR DESCRIPTION
Was previously overwriting all market info when fetching market info for a proposal, causing never ending refreshes when there are multiples proposals. Solves #105 