### PR TITLE
Seperate orderbooks by proposal

### DIFF
--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -35,13 +35,14 @@ import { useConditionalVault } from '../../hooks/useConditionalVault';
 
 export function ProposalDetailCard({ proposalNumber }: { proposalNumber: number }) {
   const { connection } = useConnection();
-  const { fetchOpenOrders, fetchProposals, orderBookObject } = useAutocrat();
+  const { fetchOpenOrders, fetchProposals } = useAutocrat();
   const { redeemTokensTransactions } = useConditionalVault();
   const wallet = useWallet();
   const {
     proposal,
     markets,
     orders,
+    orderBookObject,
     mintTokens,
     placeOrder,
     finalizeProposalTransactions,


### PR DESCRIPTION
All orderbooks were constructed using the first market data fetched, resulting in the same orderbook being displayed everywhere, as mentioned in issue #109.

Fixed by constructing the orderbook in the `useProposal` hook using local market data