### PR TITLE
fix market-sell orders

### DIFF
--- a/hooks/useOpenbookTwap.ts
+++ b/hooks/useOpenbookTwap.ts
@@ -71,13 +71,8 @@ export function useOpenbookTwap() {
     const maxBaseLots = new BN(Math.floor(amount));
     let maxQuoteLotsIncludingFees = priceLots.mul(maxBaseLots);
     if (!limitOrder) {
-      if (ask) {
-        priceLots = new BN(1);
-        maxQuoteLotsIncludingFees = new BN(Math.floor(10 / QUOTE_LOTS));
-      } else {
         priceLots = new BN(1_000_000_000_000_000);
         maxQuoteLotsIncludingFees = priceLots.mul(maxBaseLots);
-      }
     }
     return {
       side: ask ? Side.Ask : Side.Bid,


### PR DESCRIPTION
There is no need to distinguish between bid/ask when calculating `priceLots` and `maxQuoteLotsIncludingFees` for market orders.